### PR TITLE
Added support for executing shell commands via  magic in code cells.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ with open('README.rst', 'r') as f:
     long_description = f.read()
 
 setup(name='imongo-kernel',
-      version='0.1.0',
+      version='0.1.1',
       description='A MongoDB kernel for Jupyter',
       long_description=long_description,
       author='Gustavo Bezerra',


### PR DESCRIPTION
Hej Gustavo,

Thank you for your nice MongoDB kernel for Jupyter! I like it a lot, especially the visualisation of the JSON values, which are returned from the DB engine.

For a current presentation, I needed support for executing some shell commands in separate code cells next to the Mongo cells. I implemented that quickly by adding a check for if a code cell starts with a line of `%%bash`, similar to Python notebooks. Shell commands are then executed line by line and all of their output (stdout only) are then returned and displayed in a plain string.

That is working for my use cases and perhaps you think it may be useful. However, since I never did anything on Jupyter kernels, I do not know if it makes sense what I did and how I did it.


Best,
Helge