### PR TITLE
Add installation instruction via Python file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,15 @@ To install Jupyter, IMongo and all other dependencies, use ``pip install``:
 .. code:: bash
 
     $ pip install imongo-kernel
+    
+**For now, it seems like there is an issue with the installation via pip. For now, you can try to install it this way :**
+
+.. code:: bash
+
+    $ git clone https://github.com/gusutabopb/imongo
+    $ cd imongo
+    $ python setup.py install
+   
 
 Install Jupyter and IMongo Kernel using ``conda``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
As seen in #3 , we found a workaround to install the kernel though the installation via Pip is not working. The doc can be updated while the correct installation process is not working